### PR TITLE
Deploy swap pools on Mainnet and Testnet

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -1,0 +1,284 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0xF9EbbD835D811661642536891F3fB64e29a7A3ee",
+    "txHash": "0xe5e91b78e2fdd37a74fd5b74a880f57c12050881a3d4803befbe0bd46ea63680"
+  },
+  "proxies": [
+    {
+      "address": "0xc1AD5668b83e315a59D7331555DfEfc967228aCb",
+      "txHash": "0xb52dbe7bf49ce393bca88c732dceb7df05f2f89e492ba66d92c3023fb057373e",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "2208465dee4a1e4b5e745831a4498cc64b3e18221d6670c52ff833830cb0b490": {
+      "address": "0x1d0dC2deC37241435cF7552F16183Cb3C495bf60",
+      "txHash": "0xb8e8ae6ceb4805ad6cb034349a481c3b0600dbf3f572b4ee8d384e029b2e2601",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_id",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_uint256",
+            "contract": "SwapPoolStorageV1",
+            "src": "contracts\\SwapPoolStorage.sol:13"
+          },
+          {
+            "label": "_swaps",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_array(t_struct(Swap)3692_storage)dyn_storage",
+            "contract": "SwapPoolStorageV1",
+            "src": "contracts\\SwapPoolStorage.sol:16"
+          },
+          {
+            "label": "_supportedIn",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "SwapPoolStorageV1",
+            "src": "contracts\\SwapPoolStorage.sol:19"
+          },
+          {
+            "label": "_supportedOut",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "SwapPoolStorageV1",
+            "src": "contracts\\SwapPoolStorage.sol:22"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Swap)3692_storage)dyn_storage": {
+            "label": "struct ISwapPoolTypes.Swap[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(SwapStatus)3676": {
+            "label": "enum ISwapPoolTypes.SwapStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Finalized",
+              "Declined"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Swap)3692_storage": {
+            "label": "struct ISwapPoolTypes.Swap",
+            "members": [
+              {
+                "label": "tokenIn",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tokenOut",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "amountIn",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "amountOut",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "sender",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "receiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(SwapStatus)3676",
+                "offset": 20,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -1,0 +1,284 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x8074e62bA22940651491d1D544349b9B65d742CC",
+    "txHash": "0x0b22a80f3cf134adb89332f787384ae37ea57b29100ac61bf03906c3c2406f18"
+  },
+  "proxies": [
+    {
+      "address": "0xF184797143435378e4c9BE90f6e3511A1365303f",
+      "txHash": "0xf961c4bf6b0b9183dff5e884b663c7e3c1c92602ff79d47f5b509e0781d87e3d",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "2208465dee4a1e4b5e745831a4498cc64b3e18221d6670c52ff833830cb0b490": {
+      "address": "0x15f028253faef323bE257EF061fDA405448bd8D7",
+      "txHash": "0xf846f4f4dd7899d686fa3bf0cd191d03a1b4f669ceea3e0aaa90d9c68ecb98a5",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)469_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlacklistableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\BlacklistableUpgradeable.sol:139"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_id",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_uint256",
+            "contract": "SwapPoolStorageV1",
+            "src": "contracts\\SwapPoolStorage.sol:13"
+          },
+          {
+            "label": "_swaps",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_array(t_struct(Swap)3692_storage)dyn_storage",
+            "contract": "SwapPoolStorageV1",
+            "src": "contracts\\SwapPoolStorage.sol:16"
+          },
+          {
+            "label": "_supportedIn",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "SwapPoolStorageV1",
+            "src": "contracts\\SwapPoolStorage.sol:19"
+          },
+          {
+            "label": "_supportedOut",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "SwapPoolStorageV1",
+            "src": "contracts\\SwapPoolStorage.sol:22"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Swap)3692_storage)dyn_storage": {
+            "label": "struct ISwapPoolTypes.Swap[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(SwapStatus)3676": {
+            "label": "enum ISwapPoolTypes.SwapStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Finalized",
+              "Declined"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)469_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)469_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Swap)3692_storage": {
+            "label": "struct ISwapPoolTypes.Swap",
+            "members": [
+              {
+                "label": "tokenIn",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tokenOut",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "amountIn",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "amountOut",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "sender",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "receiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(SwapStatus)3676",
+                "offset": 20,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/deployed-contracts.json
+++ b/docs/deployed-contracts.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "SwapPool",
+    "chainId": 2009,
+    "address": "0xF184797143435378e4c9BE90f6e3511A1365303f"
+  },
+  {
+    "name": "SwapPool",
+    "chainId": 2008,
+    "address": "0xc1AD5668b83e315a59D7331555DfEfc967228aCb"
+  }
+]

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -1,0 +1,15 @@
+# SwapPool
+
+### CloudWalk (Mainnet)
+| # | Name | Description | Address |
+| --- | --- | --- | --- |
+| 1 | ProxyAdmin | Proxy admin | [0x8074e62bA22940651491d1D544349b9B65d742CC](https://explorer.mainnet.cloudwalk.io/address/0x8074e62bA22940651491d1D544349b9B65d742CC) |
+| 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xF184797143435378e4c9BE90f6e3511A1365303f](https://explorer.mainnet.cloudwalk.io/address/0xF184797143435378e4c9BE90f6e3511A1365303f) |
+| 3 | SwapPool | Proxy implementation | [0x15f028253faef323bE257EF061fDA405448bd8D7](https://explorer.mainnet.cloudwalk.io/address/0x15f028253faef323bE257EF061fDA405448bd8D7) |
+
+### CloudWalk (Testnet)
+| # | Name | Description | Address |
+| --- | --- | --- | --- |
+| 1 | ProxyAdmin | Proxy admin | [0xF9EbbD835D811661642536891F3fB64e29a7A3ee](https://explorer.testnet.cloudwalk.io/address/0xF9EbbD835D811661642536891F3fB64e29a7A3ee) |
+| 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xc1AD5668b83e315a59D7331555DfEfc967228aCb](https://explorer.testnet.cloudwalk.io/address/0xc1AD5668b83e315a59D7331555DfEfc967228aCb) |
+| 3 | PixCashier | Proxy implementation | [0x1d0dC2deC37241435cF7552F16183Cb3C495bf60](https://explorer.testnet.cloudwalk.io/address/0x1d0dC2deC37241435cF7552F16183Cb3C495bf60) |


### PR DESCRIPTION
### Changes
- `SwapPool` contracts have been deployed on Mainnet and Testnet;
- `deployed-contracts`  files have been created after deploying contracts;
- `.openzeppelin` network files have been created after deploying contracts.
